### PR TITLE
Modified timed_run to kill all executing threads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,9 +4,9 @@
 # ##################################################################################################
 cmake_minimum_required(VERSION 3.12)
 set(VERSION_MAJOR 1)
-set(VERSION_MINOR 0)
-set(VERSION_PATCH 1)
-set(VERSION_SUFFIX rc1)
+set(VERSION_MINOR 1)
+set(VERSION_PATCH 0)
+#set(VERSION_SUFFIX rc1)
 project(sys-vm VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 
 if(VERSION_SUFFIX)

--- a/include/sysio/vm/allocator.hpp
+++ b/include/sysio/vm/allocator.hpp
@@ -11,6 +11,7 @@
 #include <map>
 #include <set>
 #include <memory>
+#include <atomic>
 #include <mutex>
 #include <utility>
 #include <vector>
@@ -428,6 +429,7 @@ namespace sysio { namespace vm {
       char*    _code_base             = nullptr;
       size_t   _code_size             = 0;
       bool     _is_jit                = false;
+      std::atomic<uint32_t> timed_run_in_progress{0};
    };
 
    template <typename T>

--- a/include/sysio/vm/backend.hpp
+++ b/include/sysio/vm/backend.hpp
@@ -304,7 +304,7 @@ namespace sysio { namespace vm {
       }
 
       template<typename Watchdog, typename F>
-      inline auto timed_run(Watchdog&& wd, F&& f) {
+      inline void timed_run(Watchdog&& wd, F&& f) {
          // timed_run_has_timed_out -- declared in signal handling code because signal handler needs to inspect it on a SEGV too.
          // It is static because all running threads share the same timeout window. Either it is a normal transaction
          // executing on the main thread or it is a read-only transaction. All read-only transactions are limited by
@@ -326,7 +326,7 @@ namespace sysio { namespace vm {
                timed_run_has_timed_out.store(true, std::memory_order_release);
                mod->allocator.disable_code();
             });
-            return std::forward<F>(f)();
+            std::forward<F>(f)();
             --mod->allocator.timed_run_in_progress;
          } catch(wasm_memory_exception&) {
             --mod->allocator.timed_run_in_progress;

--- a/include/sysio/vm/backend.hpp
+++ b/include/sysio/vm/backend.hpp
@@ -305,25 +305,32 @@ namespace sysio { namespace vm {
 
       template<typename Watchdog, typename F>
       inline auto timed_run(Watchdog&& wd, F&& f) {
-         //timed_run_has_timed_out -- declared in signal handling code because signal handler needs to inspect it on a SEGV too -- is a thread local
-         // so that upon a SEGV the signal handling code can discern if the thread that caused the SEGV has a timed_run that has timed out. This
-         // thread local also need to be an atomic because the thread that a Watchdog callback will be called from may not be the same as the
-         // executing thread.
-         std::atomic<bool>&      _timed_out = timed_run_has_timed_out;
-         auto reenable_code = scope_guard{[&](){
-            if (_timed_out.load(std::memory_order_acquire)) {
-               mod->allocator.enable_code(Impl::is_jit);
-               _timed_out.store(false, std::memory_order_release);
+         // timed_run_has_timed_out -- declared in signal handling code because signal handler needs to inspect it on a SEGV too.
+         // It is static because all running threads share the same timeout window. Either it is a normal transaction
+         // executing on the main thread or it is a read-only transaction. All read-only transactions are limited by
+         // the same timeout so for our use case it is fine to always kill all executing transactions on a timeout.
+         // The previous timed_run_has_timed_out thread local was problematic because the timeout calling the wd_guard
+         // callback could be from any thread which would trigger the wrong timed_run_has_timed_out leaving a thread
+         // executing.
+         auto reenable_code = scope_guard{[this](){
+            if (mod->allocator.timed_run_in_progress == 0) { // last one out turns back on execution
+               if (timed_run_has_timed_out.load(std::memory_order_acquire)) {
+                  mod->allocator.enable_code(Impl::is_jit);
+                  timed_run_has_timed_out.store(false, std::memory_order_release);
+               }
             }
          }};
          try {
-            auto wd_guard = std::forward<Watchdog>(wd).scoped_run([this,&_timed_out]() {
-               _timed_out.store(true, std::memory_order_release);
+            ++mod->allocator.timed_run_in_progress;
+            auto wd_guard = std::forward<Watchdog>(wd).scoped_run([this]() {
+               timed_run_has_timed_out.store(true, std::memory_order_release);
                mod->allocator.disable_code();
             });
             return std::forward<F>(f)();
+            --mod->allocator.timed_run_in_progress;
          } catch(wasm_memory_exception&) {
-            if (_timed_out.load(std::memory_order_acquire)) {
+            --mod->allocator.timed_run_in_progress;
+            if (timed_run_has_timed_out.load(std::memory_order_acquire)) {
                throw timeout_exception{ "execution timed out" };
             } else {
                throw;

--- a/include/sysio/vm/signals.hpp
+++ b/include/sysio/vm/signals.hpp
@@ -47,23 +47,15 @@ namespace sysio { namespace vm {
          if (addr >= memory_range.data() && addr < memory_range.data() + memory_range.size())
             siglongjmp(*dest, sig);
 
-         //a failure in the code range...
-         //a failure should always be in the code_memory_range when dest set in a timed_run.
          //timed_run_has_timed_out is static and therefore applies to all threads. See backend timed_run for details.
          // SEGV/BUS because the code_memory_range was set to PROT_NONE.
          // On linux no SIGBUS handler is registered (see setup_signal_handler_impl()) so it will never occur here
-         if (addr >= code_memory_range.data() && addr < code_memory_range.data() + code_memory_range.size()) {
-            //a SEGV/BUS in the code range when timed_run_has_timed_out=false is due to a _different_ thread's execution activating a deadline
-            // timer. Return and retry executing the same code again. Eventually timed_run() on the other thread will reset the page
-            // permissions and progress on this thread can continue
-            //on linux no SIGBUS handler is registered (see setup_signal_handler_impl()) so it will never occur here
-            if ((sig == SIGSEGV || sig == SIGBUS) && timed_run_has_timed_out.load(std::memory_order_acquire) == false)
-               return;
-            //otherwise, jump out
-            siglongjmp(*dest, sig);
-         }
+         if ((sig == SIGSEGV || sig == SIGBUS) && timed_run_has_timed_out.load(std::memory_order_acquire) == false)
+            return;
+         //otherwise, jump out
+         siglongjmp(*dest, sig);
 
-         //if in neither range, fall through and let chained handler an opportunity to handle
+         //if dest not set, fall through and let chained handler an opportunity to handle
       }
 
       struct sigaction* prev_action;


### PR DESCRIPTION
## Change Description

Version bump to 1.1.0

Too many long running read-only trxs can cause one or more of the long running trxs to not be terminated. The problem is that many read-only trxs run in the same large memory space. This memory space is marked un-executable to kill the read-only trx. However, when multiple are being killed at the same time then the memory space can be put back into execution mode before all the trxs that should be killed are killed. This leaves one or more running. With nothing to interrupt the trx it can run indefinitely.

For example:
trx1, trx2 running
trx1, trx2 timers expire at the same time
trx1 marks memory as unexecutable
trx2 marks memory as unexecutable also
trx1 tries another JIT execution
trx1 is interrupted and exits
trx1 sets memory back as executable
trx2 tries another JIT execution, but is fine because memory is again executable trx2 continues to run forever

This PR takes a simpler approach for the use-cases of Wire/Spring. In Wire/Spring all executing timed run threads share the same time out. Either it is a single main thread transaction with a timeout or it is multiple read-only threads running with a timeout of the read-only-window. In either case the desire is to kill all threads.

## API Changes

It is now possible for `timed_run` to throw a `timeout_exception` for a thread that has not timed out yet. It would time out soon since all threads share the same timeout time, but there is a race on which timer fire first. Spring/Wire need to be updated to expect a `timeout_exception` for a `apply` thread whose timer has not timed out yet. Before calling `checktime()` that thread needs to first make sure the timer is in the expired state. Otherwise the `checktime()` will be ignored.

## Documentation Additions

None