### PR TITLE
Updated dependency configs for llvm18 migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ compile_commands.json
 Testing/
 
 .!*!*
+
+# Claude
+/.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+> Important: eos-vm is synonymous with sys-vm in this repository.
+
+Wire SYS VM (formerly EOS VM) is a high-performance WebAssembly engine designed for blockchain applications. It prioritizes deterministic execution, time-bounded execution, and security. The library is **header-only** (except for the softfloat dependency) and targets **Unix-like OSes only** (Linux, macOS). Current version: 1.1.0.
+
+## Build Commands
+
+### Initial Setup
+```bash
+git submodule update --init --recursive
+./vcpkg/bootstrap-vcpkg.sh
+```
+
+### Configure and Build
+```bash
+# Debug build, use build/claude
+# Release build, use build/claude-release
+cmake -S . -B build/claude \
+  -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake \
+  -DENABLE_TESTS=ON \
+  -DENABLE_SPEC_TESTS=ON \
+  -DCMAKE_BUILD_TYPE=Debug
+
+cmake --build build/claude -- -j$(nproc)
+```
+
+### Run All Tests
+```bash
+cd build/claude && ctest -j$(nproc) --output-on-failure
+```
+
+### Run a Single Test
+Tests use Catch2 and are discovered via CTest. To run a specific test by name:
+various ways:
+```bash
+cd build/claude && ctest -R <test_name_regex> --output-on-failure
+```
+Or run a test executable directly with Catch2 filtering:
+```bash
+./build/claude/tests/unit_tests "<test case name>"
+./build/claude/tests/sys_vm_spec_tests "<test case name>"
+```
+
+### Key CMake Options
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ENABLE_SOFTFLOAT` | ON | Deterministic software floating-point |
+| `ENABLE_TESTS` | OFF | Build unit + spec tests |
+| `ENABLE_SPEC_TESTS` | ON (if tests) | WebAssembly spec compliance tests |
+| `ENABLE_FUZZ_TESTS` | OFF | Fuzzing harness |
+| `ENABLE_TOOLS` | ON | Build example tools (interp, bench, hello_driver) |
+| `FULL_DEBUG_BUILD` | ON in Debug | Stack dumps and instruction tracing |
+| `ENABLE_MEMORY_OPS_ALIGNMENT` | OFF | Obey alignment hints |
+
+## Architecture
+
+### Core Library (`include/sysio/vm/`)
+
+The engine is template-heavy C++20. All core types live in namespace `sysio::vm`.
+
+**Backend** (`backend.hpp`): The main API entry point. Template-parameterized by:
+- `HostFunctions` — registered native functions callable from WASM
+- `Impl` — execution backend: `interpreter` (default), `jit` (x86-64 only), `jit_profile`, `null_backend`
+- `Options` — compile-time or runtime configurable limits
+- `DebugInfo` — optional debug information
+
+**Execution flow**: `wasm_allocator` → `watchdog` (timeout) → `backend` (parse + instantiate) → execute exports via `backend(host, "module", "func", args...)`.
+
+**Parser** (`parser.hpp`, ~1800 lines): Single-pass O(n) binary WASM parser with bounds checking. Handles LEB128 decoding (`leb128.hpp`), section parsing (`sections.hpp`), and validation (`validation.hpp`).
+
+**Interpreter** (`execution_context.hpp` + `interpret_visitor.hpp`): Stack-machine bytecode interpreter using a visitor pattern with static dispatch (not virtual). Opcodes defined in `opcodes_def.hpp` and `opcodes.hpp`.
+
+**JIT** (`x86_64.hpp`, ~2600 lines): x86-64 native code generation backend. Only available on x86_64.
+
+**Memory** (`allocator.hpp`): Multiple allocator strategies — `bounded_allocator`, `stack_allocator` (guard-paged stacks), `contiguous_allocator` (mmap-based), `growable_allocator`. Guard paging provides memory sandboxing.
+
+**Host Functions** (`host_function.hpp`): Type-safe registration via `registered_host_functions<HostClass>::add<&method>("module", "name")`. Supports C functions, static methods, and instance methods with automatic WASM↔native type conversion.
+
+**Watchdog** (`watchdog.hpp`): Time-bounded execution using background thread timers. `null_watchdog` for unbounded execution. Multi-threaded timeout uses atomic tracking of in-progress threads.
+
+**Custom Data Types**: `variant.hpp` (fast discriminated union for opcodes/stack), `vector.hpp` (non-owning fast vector backed by allocators), `wasm_stack.hpp`.
+
+**Signals** (`signals.hpp`): Signal handling for watchdog timeout interrupts and guard page violations.
+
+### Tests (`tests/`)
+
+- **Unit tests** (`tests/*.cpp`): ~30 test files covering allocators, host functions, watchdog, signals, configuration limits, backend behavior. Built as `unit_tests` executable.
+- **Spec tests** (`tests/spec/`): ~79 WebAssembly spec compliance test suites. Built as `sys_vm_spec_tests` executable. Test WASM binaries fetched from `wire-network/wire-sys-vm-test-wasms`.
+- **Fuzz tests** (`tests/fuzz/`): Optional fuzzing harness.
+
+Test framework: **Catch2** configured with `CATCH_CONFIG_NO_POSIX_SIGNALS` (the VM handles signals itself).
+
+### Tools (`tools/`)
+
+- `sys-vm-interp` — standalone WASM interpreter, runs all exports
+- `bench-interp` — benchmarking (parse/instantiate + execution time)
+- `hello-driver` — host function integration example
+
+### Dependencies
+
+Managed via **vcpkg** (git submodule):
+- **softfloat** — deterministic IEEE-754 floating-point
+- **Catch2** — testing (with no-posix-signals feature)
+
+## Key Design Constraints
+
+- No unbounded recursion or loops in parsing/execution
+- All collections are bounded or validated
+- Guard paging makes pointer validation in host functions unnecessary (but host functions must be able to fail hard without calling destructors)
+- Non-owning data structures — objects are constructed in-place in allocator memory and never copied
+- Atomic synchronization for multi-threaded `timed_run` coordination
+- Softfloat ensures cross-platform determinism for consensus

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -11,4 +11,9 @@ file(COPY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/catch.hpp" DES
 
 # Softfloat
 find_package(Threads REQUIRED)
-find_package(softfloat CONFIG REQUIRED) 
+find_package(softfloat CONFIG REQUIRED)
+
+# LLVM
+find_package(LLVM CONFIG REQUIRED)
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Using LLVMConfig.cmake at: ${LLVM_DIR}")

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "0ceb5cc73ca439f6ac0fb8b185b82afd75070bc1",
+      "baseline": "add9228a61ce5eb1dc41f89d07254b7531b2bdfc",
       "packages": [
         "softfloat",
         "libsodium",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,12 +2,27 @@
   "name": "wire-sys-vm",
   "version": "5.2.0-rc1",
   "dependencies": [
+    "softfloat",
     {
       "name": "catch2",
       "features": [
         "no-posix-signals"
       ]
     },
-    "softfloat"
+    {
+      "name": "llvm",
+      "default-features": true,
+      "features": [
+        "enable-rtti",
+        "target-aarch64",
+        "target-x86"
+      ]
+    }
+  ],
+  "overrides": [
+    {
+      "name": "llvm",
+      "version": "18.1.6#5"
+    }
   ]
 }


### PR DESCRIPTION
This pull request introduces initial support for LLVM as a dependency, updates the vcpkg registry baseline, and adds comprehensive developer documentation for the project. The most important changes are summarized below:

**Dependency and Build System Updates:**

* Added LLVM as a required dependency in both `vcpkg.json` (with specific features and version override) and `cmake/dependencies.cmake`, ensuring consistent LLVM integration across builds. [[1]](diffhunk://#diff-dbbb1b147126744a5eee012901d2b9a29cc478be03677f67825b9b2794f5d283R5-R26) [[2]](diffhunk://#diff-02b58b3ce9a71b92b93137c7a00f4fe64adb1c6a74364f0fe6fda27b45d7808bR15-R19)
* Updated the vcpkg registry baseline in `vcpkg-configuration.json` to a newer commit, which may include updated or additional packages.

**Documentation:**

* Added a new `CLAUDE.md` file providing an in-depth project overview, build instructions, architecture explanation, and key design constraints for developers and AI coding tools.