### PR TITLE
Use fetched Catch2 and simplify vcpkg dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 # build sys-vm or integrate with another system with CMake.
 # ##################################################################################################
 cmake_minimum_required(VERSION 3.12)
+
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 1)
 set(VERSION_PATCH 0)
@@ -145,4 +146,3 @@ if(ENABLE_INSTALL)
       endif()
    endif()
 endif()
-

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -3,17 +3,6 @@
 
 include(GNUInstallDirs)
 
-# Catch2
-find_package(Catch2 CONFIG REQUIRED)
-list(APPEND CMAKE_MODULE_PATH "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/share/catch2")
-file(MAKE_DIRECTORY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/catch2")
-file(COPY "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/catch.hpp" DESTINATION "${VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/include/catch2")
-
 # Softfloat
 find_package(Threads REQUIRED)
 find_package(softfloat CONFIG REQUIRED)
-
-# LLVM
-find_package(LLVM CONFIG REQUIRED)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake at: ${LLVM_DIR}")

--- a/include/sysio/vm/signals.hpp
+++ b/include/sysio/vm/signals.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <sysio/vm/allocator.hpp>
 #include <sysio/vm/exceptions.hpp>
 #include <sysio/vm/span.hpp>
 #include <sysio/vm/utils.hpp>
@@ -156,7 +157,7 @@ namespace sysio { namespace vm {
       sigjmp_buf dest;
       sigjmp_buf* volatile old_signal_handler = nullptr;
       code_memory_range = code_allocator.get_code_span();
-      memory_range = mem_allocator->get_span();
+      memory_range = mem_allocator ? mem_allocator->get_span() : std::span<std::byte>{};
       int sig;
       if((sig = sigsetjmp(dest, 1)) == 0) {
          // Note: Cannot use RAII, as non-trivial destructors w/ longjmp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,20 @@
 # ############
 
 enable_testing()
+include(FetchContent)
+
+set(CATCH_BUILD_TESTING OFF CACHE BOOL "Disable Catch2 self-tests")
+set(CATCH_INSTALL_DOCS OFF CACHE BOOL "Disable Catch2 documentation install")
+set(CATCH_INSTALL_HELPERS OFF CACHE BOOL "Disable Catch2 helper install")
+
+FetchContent_Declare(
+   Catch2
+   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+   GIT_TAG 9c741fe96073ed620ffc032afbed1f3c789d2b68
+)
+FetchContent_MakeAvailable(Catch2)
+
+list(APPEND CMAKE_MODULE_PATH "${catch2_SOURCE_DIR}/contrib")
 include(Catch)
 
 # OPTIONS
@@ -88,7 +102,7 @@ if(ENABLE_SPEC_TESTS)
 
    add_executable(sys_vm_spec_tests main.cpp ${SPEC_TESTS})
    setup_vm_target(sys_vm_spec_tests)
-   target_link_libraries(sys_vm_spec_tests sys-vm Catch2::Catch2WithMain)
+   target_link_libraries(sys_vm_spec_tests sys-vm Catch2::Catch2)
    target_include_directories(
       sys_vm_spec_tests
       PUBLIC
@@ -166,9 +180,8 @@ add_executable(unit_tests main.cpp
    backend_tests.cpp
    vector_tests.cpp)
 setup_vm_target(unit_tests)
-target_link_libraries(unit_tests sys-vm Catch2::Catch2WithMain)
+target_link_libraries(unit_tests sys-vm Catch2::Catch2)
 target_compile_definitions(unit_tests PUBLIC -DCATCH_CONFIG_NO_POSIX_SIGNALS)
 
 # UNIT_TESTS: Discover
 catch_discover_tests(unit_tests)
-

--- a/tests/fuzz/CMakeLists.txt
+++ b/tests/fuzz/CMakeLists.txt
@@ -1,8 +1,23 @@
-set(CMAKE_CXX_FLAGS "-g -O1 -fsanitize-coverage=trace-pc-guard,indirect-calls,trace-cmp,trace-div,trace-gep -gline-tables-only")
+include(CheckCXXSourceCompiles)
 
-find_package(LLVM REQUIRED CONFIG)
-message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake at: ${LLVM_DIR}")
+set(SYS_VM_FUZZ_SANITIZER_FLAGS "-fsanitize=fuzzer,address")
+set(SYS_VM_FUZZ_DEBUG_FLAGS "-g" "-O1" "-gline-tables-only")
+
+set(CMAKE_REQUIRED_FLAGS_SAVE "${CMAKE_REQUIRED_FLAGS}")
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} ${SYS_VM_FUZZ_SANITIZER_FLAGS}")
+check_cxx_source_compiles([=[
+   #include <cstddef>
+   #include <cstdint>
+
+   extern "C" int LLVMFuzzerTestOneInput(const std::uint8_t*, std::size_t) {
+      return 0;
+   }
+]=] SYS_VM_HAS_FUZZER_ADDRESS_SANITIZER)
+set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS_SAVE}")
+
+if(NOT SYS_VM_HAS_FUZZER_ADDRESS_SANITIZER)
+    message(FATAL_ERROR "ENABLE_FUZZ_TESTS requires compiler/linker support for ${SYS_VM_FUZZ_SANITIZER_FLAGS}")
+endif()
 
 function(add_libfuzzer_test name)
     set(multi_arg_options "SOURCES")
@@ -15,10 +30,10 @@ function(add_libfuzzer_test name)
         ${add_libfuzzer_test_SOURCES}
     )
     setup_vm_target(LLVMFuzzer-${name})
-    target_compile_options(LLVMFuzzer-${name} PUBLIC "-fsanitize=fuzzer,address")
-    target_link_libraries(LLVMFuzzer-${name} PUBLIC sys-vm "-fsanitize=fuzzer,address")
+    target_compile_options(LLVMFuzzer-${name} PUBLIC ${SYS_VM_FUZZ_DEBUG_FLAGS} ${SYS_VM_FUZZ_SANITIZER_FLAGS})
+    target_link_libraries(LLVMFuzzer-${name} sys-vm ${SYS_VM_FUZZ_SANITIZER_FLAGS})
 endfunction()
 
 add_libfuzzer_test(wasm_fuzz_test SOURCES fuzz_driver.cpp)
 
-add_test(wasm_libfuzzer COMMAND ${CMAKE_CURRENT_BINARY_DIR}/LLVMFuzzer-wasm_fuzz_test -jobs=40 ${CMAKE_CURRENT_SOURCE_DIR}/corpus)
+add_test(NAME wasm_libfuzzer COMMAND ${CMAKE_CURRENT_BINARY_DIR}/LLVMFuzzer-wasm_fuzz_test -runs=1 -jobs=1 -rss_limit_mb=6144 -timeout=30 ${CMAKE_CURRENT_SOURCE_DIR}/corpus)

--- a/tests/fuzz/fuzz_driver.cpp
+++ b/tests/fuzz/fuzz_driver.cpp
@@ -1,14 +1,24 @@
-#include <sysio/wasm_backend/backend.hpp>
+#include <sysio/vm/backend.hpp>
 #include <sysio/vm/watchdog.hpp>
 
+#include <chrono>
+#include <cstring>
+#include <exception>
+
 using namespace sysio;
-using namespace sysio::wasm_backend;
+using namespace sysio::vm;
 
 extern "C" int LLVMFuzzerTestOneInput( const uint8_t* data, size_t size ) {
    wasm_allocator wa;
    wasm_code wc; 
    wc.resize(size);
    memcpy((uint8_t*)wc.data(), data, size);
-   backend<std::nullptr_t> bkend( wc );
-   bkend.execute_all(null_watchdog());
+   try {
+      backend<std::nullptr_t> bkend( wc, &wa );
+      bkend.execute_all(watchdog{std::chrono::milliseconds(100)});
+   } catch(const std::exception&) {
+      // Invalid or long-running fuzz inputs are expected to throw VM exceptions.
+      // Returning 0 tells libFuzzer the input was rejected cleanly.
+   }
+   return 0;
 }

--- a/tests/reentry_tests.cpp
+++ b/tests/reentry_tests.cpp
@@ -53,10 +53,10 @@ BACKEND_TEST_CASE("test reentry", "[reentry]") {
    struct test_runner {
       backend_t* bkend;
       uint32_t test_func_0(uint32_t val) {
-         return bkend->call_with_return(*this, "env", "bar", val)->to_ui32() + 50;
+         return bkend->call_with_return(*this, "env", "bar", static_cast<uint32_t>(val))->to_ui32() + 50;
       }
       uint32_t test_func_1(uint32_t val) {
-         return bkend->call_with_return(*this, "env", "testbar", val)->to_ui32() + 50;
+         return bkend->call_with_return(*this, "env", "testbar", static_cast<uint32_t>(val))->to_ui32() + 50;
       }
    };
 

--- a/tests/signals_tests.cpp
+++ b/tests/signals_tests.cpp
@@ -10,12 +10,16 @@ struct test_exception {};
 
 TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
    bool okay = false;
+   // These tests call the signal handler directly, outside a real VM execution.
+   // A null memory allocator intentionally leaves memory_range empty so the
+   // handler exercises its legacy catch-all path.
+   sysio::vm::growable_allocator code_allocator;
    try {
       sysio::vm::invoke_with_signal_handler([]() {
          std::raise(SIGSEGV);
       }, [](int sig) {
          throw test_exception{};
-      }, {}, {});
+      }, code_allocator, nullptr);
    } catch(test_exception&) {
       okay = true;
    }
@@ -23,9 +27,11 @@ TEST_CASE("Testing signals", "[invoke_with_signal_handler]") {
 }
 
 TEST_CASE("Testing throw", "[signal_handler_throw]") {
+   // See the signal test above: no wasm memory is involved in this direct path.
+   sysio::vm::growable_allocator code_allocator;
    CHECK_THROWS_AS(sysio::vm::invoke_with_signal_handler([](){
       sysio::vm::throw_<sysio::vm::wasm_exit_exception>( "Exiting" );
-   }, [](int){}, {}, {}), sysio::vm::wasm_exit_exception);
+   }, [](int){}, code_allocator, nullptr), sysio::vm::wasm_exit_exception);
 }
 
 static volatile sig_atomic_t sig_handled;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -11,15 +11,7 @@
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
       "baseline": "add9228a61ce5eb1dc41f89d07254b7531b2bdfc",
       "packages": [
-        "softfloat",
-        "libsodium",
-        "cli11",
-        "catch2",
-        "boost",
-        "boringssl-custom",
-        "secp256k1-internal",
-        "bn256",
-        "bls12-381"
+        "softfloat"
       ]
     }
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,27 +2,6 @@
   "name": "wire-sys-vm",
   "version": "5.2.0-rc1",
   "dependencies": [
-    "softfloat",
-    {
-      "name": "catch2",
-      "features": [
-        "no-posix-signals"
-      ]
-    },
-    {
-      "name": "llvm",
-      "default-features": true,
-      "features": [
-        "enable-rtti",
-        "target-aarch64",
-        "target-x86"
-      ]
-    }
-  ],
-  "overrides": [
-    {
-      "name": "llvm",
-      "version": "18.1.6#5"
-    }
+    "softfloat"
   ]
 }


### PR DESCRIPTION
## Summary

This removes Catch2 and LLVM from the vcpkg manifest/custom registry path. `softfloat` is now the only vcpkg dependency for eos-vm.

Catch2 is only used when `ENABLE_TESTS=ON`. The `wire-sys-vm` registry port explicitly configures eos-vm with tests disabled, so depending on Catch2 during vcpkg packaging was unnecessary in the first place. On top of that, eos-vm intentionally uses an old Catch2 revision, matching the original eos-vm `external/Catch2` submodule commit. That old Catch2 version is not shared by the other repos in the Wire system. Maintaining an independent vcpkg Catch2 port, with a `no-posix-signals` configuration used only by this repo's tests, adds registry maintenance without providing reuse value.

Instead, eos-vm tests now use CMake `FetchContent` pinned to the historical Catch2 commit:

- `9c741fe96073ed620ffc032afbed1f3c789d2b68`

This keeps the Catch2 choice local to eos-vm tests and lets the shared Wire vcpkg registry stop carrying repo-specific Catch2 behavior.

LLVM is removed for the same reason: it is not used by the sys-vm library or packaging path. The VM JIT is hand-written machine-code emission, not LLVM. The only local LLVM-related use was the fuzz-test setup, so the fuzz CMake now checks whether the active compiler supports `-fsanitize=fuzzer,address` directly instead of forcing every vcpkg consumer to install a large LLVM package.

## Changes

- Remove `catch2` and `llvm` from `vcpkg.json`; `softfloat` is now the only vcpkg dependency.
- Trim `vcpkg-configuration.json` so the Wire custom registry only owns `softfloat` for this repo.
- Remove global `find_package(Catch2)` and `find_package(LLVM)` from dependency setup.
- Use `FetchContent` for the pinned Catch2 test dependency.
- Keep `CATCH_CONFIG_NO_POSIX_SIGNALS` on test targets.
- Update direct signal-handler tests to pass explicit allocator arguments and document the empty-memory-range behavior.
- Update fuzz test wiring to check compiler support for `-fsanitize=fuzzer,address` instead of depending on a vcpkg LLVM package.
- Fix the fuzz harness for the current `sysio::vm` API and add a VM watchdog so long-running wasm corpus inputs are rejected cleanly.

## Validation

- Fresh configure with `ENABLE_TESTS=OFF` passes; vcpkg resolves only `softfloat` plus helper ports.
- Fresh configure/build with tests enabled passed for the main test targets during local validation.
- Signal/trap smoke tests passed with the fetched Catch2 revision.
- Fuzz support was tested with `clang-18`:
  - compiler probe for `-fsanitize=fuzzer,address` passes
  - `LLVMFuzzer-wasm_fuzz_test` builds
  - `ctest -R wasm_libfuzzer` passes with the full current corpus

## Notes

No changes are required in `wire-vcpkg-registry` for this PR, but after this lands the custom Catch2 port there should be removable if no other repo depends on it.
