### PR TITLE
Support renamed SoftFloat types

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.12)
 
 set(VERSION_MAJOR 1)
 set(VERSION_MINOR 1)
-set(VERSION_PATCH 0)
+set(VERSION_PATCH 1)
 #set(VERSION_SUFFIX rc1)
 project(sys-vm VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 

--- a/include/sysio/vm/softfloat.hpp
+++ b/include/sysio/vm/softfloat.hpp
@@ -10,10 +10,10 @@ namespace sysio { namespace vm {
 inline constexpr uint32_t inv_float_eps = 0x4B000000;
 inline constexpr uint64_t inv_double_eps = 0x4330000000000000;
 
-inline bool is_nan( const float32_t f ) {
+inline bool is_nan( const softfloat32_t f ) {
    return f32_is_nan( f );
 }
-inline bool is_nan( const float64_t f ) {
+inline bool is_nan( const softfloat64_t f ) {
    return f64_is_nan( f );
 }
 
@@ -34,8 +34,8 @@ inline float _sysio_f32_mul( float a, float b ) {
 }
 
 inline float _sysio_f32_min( float af, float bf ) {
-   float32_t a = to_softfloat32(af);
-   float32_t b = to_softfloat32(bf);
+   softfloat32_t a = to_softfloat32(af);
+   softfloat32_t b = to_softfloat32(bf);
    if (is_nan(a)) {
       return af;
    }
@@ -49,8 +49,8 @@ inline float _sysio_f32_min( float af, float bf ) {
 }
 
 inline float _sysio_f32_max( float af, float bf ) {
-   float32_t a = to_softfloat32(af);
-   float32_t b = to_softfloat32(bf);
+   softfloat32_t a = to_softfloat32(af);
+   softfloat32_t b = to_softfloat32(bf);
    if (is_nan(a)) {
       return af;
    }
@@ -64,21 +64,21 @@ inline float _sysio_f32_max( float af, float bf ) {
 }
 
 inline float _sysio_f32_copysign( float af, float bf ) {
-   float32_t a = to_softfloat32(af);
-   float32_t b = to_softfloat32(bf);
+   softfloat32_t a = to_softfloat32(af);
+   softfloat32_t b = to_softfloat32(bf);
    a.v &= ~(1 << 31);             // clear the sign bit
    a.v = a.v | ((b.v >> 31) << 31); // add the sign of b
    return from_softfloat32(a);
 }
 
 inline float _sysio_f32_abs( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    a.v &= ~(1 << 31);
    return from_softfloat32(a);
 }
 
 inline float _sysio_f32_neg( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    uint32_t sign = a.v >> 31;
    a.v &= ~(1 << 31);
    a.v |= (!sign << 31);
@@ -86,12 +86,12 @@ inline float _sysio_f32_neg( float af ) {
 }
 
 inline float _sysio_f32_sqrt( float a ) {
-   float32_t ret = ::f32_sqrt( to_softfloat32(a) );
+   softfloat32_t ret = ::f32_sqrt( to_softfloat32(a) );
    return from_softfloat32(ret);
 }
 
 inline float _sysio_f32_ceil( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    int e = (int)(a.v >> 23 & 0xFF) - 0X7F;
    uint32_t m;
    if (e >= 23)
@@ -114,7 +114,7 @@ inline float _sysio_f32_ceil( float af ) {
 }
 
 inline float _sysio_f32_floor( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    int e = (int)(a.v >> 23 & 0xFF) - 0X7F;
    uint32_t m;
    if (e >= 23)
@@ -136,7 +136,7 @@ inline float _sysio_f32_floor( float af ) {
 }
 
 inline float _sysio_f32_trunc( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    int e = (int)(a.v >> 23 & 0xff) - 0x7f + 9;
    uint32_t m;
    if (e >= 23 + 9)
@@ -151,16 +151,16 @@ inline float _sysio_f32_trunc( float af ) {
 }
 
 inline float _sysio_f32_nearest( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    int e = a.v>>23 & 0xff;
    int s = a.v>>31;
-   float32_t y;
+   softfloat32_t y;
    if (e >= 0x7f+23)
       return af;
    if (s)
-      y = ::f32_add( ::f32_sub( a, float32_t{inv_float_eps} ), float32_t{inv_float_eps} );
+      y = ::f32_add( ::f32_sub( a, softfloat32_t{inv_float_eps} ), softfloat32_t{inv_float_eps} );
    else
-      y = ::f32_sub( ::f32_add( a, float32_t{inv_float_eps} ), float32_t{inv_float_eps} );
+      y = ::f32_sub( ::f32_add( a, softfloat32_t{inv_float_eps} ), softfloat32_t{inv_float_eps} );
    if (::f32_eq( y, {0} ) )
       return s ? -0.0f : 0.0f;
    return from_softfloat32(y);
@@ -171,8 +171,8 @@ inline bool _sysio_f32_ne( float a, float b ) { return !::f32_eq( to_softfloat32
 inline bool _sysio_f32_lt( float a, float b ) { return ::f32_lt( to_softfloat32(a), to_softfloat32(b) ); }
 inline bool _sysio_f32_le( float a, float b ) { return ::f32_le( to_softfloat32(a), to_softfloat32(b) ); }
 inline bool _sysio_f32_gt( float af, float bf ) {
-   float32_t a = to_softfloat32(af);
-   float32_t b = to_softfloat32(bf);
+   softfloat32_t a = to_softfloat32(af);
+   softfloat32_t b = to_softfloat32(bf);
    if (is_nan(a))
       return false;
    if (is_nan(b))
@@ -181,8 +181,8 @@ inline bool _sysio_f32_gt( float af, float bf ) {
 }
 
 inline bool _sysio_f32_ge( float af, float bf ) {
-   float32_t a = to_softfloat32(af);
-   float32_t b = to_softfloat32(bf);
+   softfloat32_t a = to_softfloat32(af);
+   softfloat32_t b = to_softfloat32(bf);
    if (is_nan(a))
       return false;
    if (is_nan(b))
@@ -191,28 +191,28 @@ inline bool _sysio_f32_ge( float af, float bf ) {
 }
 
 inline double _sysio_f64_add( double a, double b ) {
-   float64_t ret = ::f64_add( to_softfloat64(a), to_softfloat64(b) );
+   softfloat64_t ret = ::f64_add( to_softfloat64(a), to_softfloat64(b) );
    return from_softfloat64(ret);
 }
 
 inline double _sysio_f64_sub( double a, double b ) {
-   float64_t ret = ::f64_sub( to_softfloat64(a), to_softfloat64(b) );
+   softfloat64_t ret = ::f64_sub( to_softfloat64(a), to_softfloat64(b) );
    return from_softfloat64(ret);
 }
 
 inline double _sysio_f64_div( double a, double b ) {
-   float64_t ret = ::f64_div( to_softfloat64(a), to_softfloat64(b) );
+   softfloat64_t ret = ::f64_div( to_softfloat64(a), to_softfloat64(b) );
    return from_softfloat64(ret);
 }
 
 inline double _sysio_f64_mul( double a, double b ) {
-   float64_t ret = ::f64_mul( to_softfloat64(a), to_softfloat64(b) );
+   softfloat64_t ret = ::f64_mul( to_softfloat64(a), to_softfloat64(b) );
    return from_softfloat64(ret);
 }
 
 inline double _sysio_f64_min( double af, double bf ) {
-   float64_t a = to_softfloat64(af);
-   float64_t b = to_softfloat64(bf);
+   softfloat64_t a = to_softfloat64(af);
+   softfloat64_t b = to_softfloat64(bf);
    if (is_nan(a))
       return af;
    if (is_nan(b))
@@ -223,8 +223,8 @@ inline double _sysio_f64_min( double af, double bf ) {
 }
 
 inline double _sysio_f64_max( double af, double bf ) {
-   float64_t a = to_softfloat64(af);
-   float64_t b = to_softfloat64(bf);
+   softfloat64_t a = to_softfloat64(af);
+   softfloat64_t b = to_softfloat64(bf);
    if (is_nan(a))
       return af;
    if (is_nan(b))
@@ -235,21 +235,21 @@ inline double _sysio_f64_max( double af, double bf ) {
 }
 
 inline double _sysio_f64_copysign( double af, double bf ) {
-   float64_t a = to_softfloat64(af);
-   float64_t b = to_softfloat64(bf);
+   softfloat64_t a = to_softfloat64(af);
+   softfloat64_t b = to_softfloat64(bf);
    a.v &= ~(uint64_t(1) << 63);     // clear the sign bit
    a.v = a.v | ((b.v >> 63) << 63); // add the sign of b
    return from_softfloat64(a);
 }
 
 inline double _sysio_f64_abs( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    a.v &= ~(uint64_t(1) << 63);
    return from_softfloat64(a);
 }
 
 inline double _sysio_f64_neg( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    uint64_t sign = a.v >> 63;
    a.v &= ~(uint64_t(1) << 63);
    a.v |= (uint64_t(!sign) << 63);
@@ -257,25 +257,25 @@ inline double _sysio_f64_neg( double af ) {
 }
 
 inline double _sysio_f64_sqrt( double a ) {
-   float64_t ret = ::f64_sqrt( to_softfloat64(a) );
+   softfloat64_t ret = ::f64_sqrt( to_softfloat64(a) );
    return from_softfloat64(ret);
 }
 
 inline double _sysio_f64_ceil( double af ) {
-   float64_t a = to_softfloat64( af );
-   float64_t ret;
+   softfloat64_t a = to_softfloat64( af );
+   softfloat64_t ret;
    int e = a.v >> 52 & 0x7ff;
-   float64_t y;
+   softfloat64_t y;
    if (e >= 0x3ff+52 || ::f64_eq( a, { 0 } ))
       return af;
    /* y = int(x) - x, where int(x) is an integer neighbor of x */
    if (a.v >> 63)
-      y = ::f64_sub( ::f64_add( ::f64_sub( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} ), a );
+      y = ::f64_sub( ::f64_add( ::f64_sub( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} ), a );
    else
-      y = ::f64_sub( ::f64_sub( ::f64_add( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} ), a );
+      y = ::f64_sub( ::f64_sub( ::f64_add( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} ), a );
    /* special case because of non-nearest rounding modes */
    if (e <= 0x3ff-1) {
-      return a.v >> 63 ? -0.0 : 1.0; //float64_t{0x8000000000000000} : float64_t{0xBE99999A3F800000}; //either -0.0 or 1
+      return a.v >> 63 ? -0.0 : 1.0; //softfloat64_t{0x8000000000000000} : softfloat64_t{0xBE99999A3F800000}; //either -0.0 or 1
    }
    if (::f64_lt( y, to_softfloat64(0) )) {
       ret = ::f64_add( ::f64_add( a, y ), to_softfloat64(1) ); // 0xBE99999A3F800000 } ); // plus 1
@@ -286,10 +286,10 @@ inline double _sysio_f64_ceil( double af ) {
 }
 
 inline double _sysio_f64_floor( double af ) {
-   float64_t a = to_softfloat64( af );
-   float64_t ret;
+   softfloat64_t a = to_softfloat64( af );
+   softfloat64_t ret;
    int e = a.v >> 52 & 0x7FF;
-   float64_t y;
+   softfloat64_t y;
    if ( a.v == 0x8000000000000000) {
       return af;
    }
@@ -297,13 +297,13 @@ inline double _sysio_f64_floor( double af ) {
       return af;
    }
    if (a.v >> 63)
-      y = ::f64_sub( ::f64_add( ::f64_sub( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} ), a );
+      y = ::f64_sub( ::f64_add( ::f64_sub( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} ), a );
    else
-      y = ::f64_sub( ::f64_sub( ::f64_add( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} ), a );
+      y = ::f64_sub( ::f64_sub( ::f64_add( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} ), a );
    if (e <= 0x3FF-1) {
-      return a.v>>63 ? -1.0 : 0.0; //float64_t{0xBFF0000000000000} : float64_t{0}; // -1 or 0
+      return a.v>>63 ? -1.0 : 0.0; //softfloat64_t{0xBFF0000000000000} : softfloat64_t{0}; // -1 or 0
    }
-   if ( !::f64_le( y, float64_t{0} ) ) {
+   if ( !::f64_le( y, softfloat64_t{0} ) ) {
       ret = ::f64_sub( ::f64_add(a,y), to_softfloat64(1.0));
       return from_softfloat64(ret);
    }
@@ -312,7 +312,7 @@ inline double _sysio_f64_floor( double af ) {
 }
 
 inline double _sysio_f64_trunc( double af ) {
-   float64_t a = to_softfloat64( af );
+   softfloat64_t a = to_softfloat64( af );
    int e = (int)(a.v >> 52 & 0x7ff) - 0x3ff + 12;
    uint64_t m;
    if (e >= 52 + 12)
@@ -327,17 +327,17 @@ inline double _sysio_f64_trunc( double af ) {
 }
 
 inline double _sysio_f64_nearest( double af ) {
-   float64_t a = to_softfloat64( af );
+   softfloat64_t a = to_softfloat64( af );
    int e = (a.v >> 52 & 0x7FF);
    int s = a.v >> 63;
-   float64_t y;
+   softfloat64_t y;
    if ( e >= 0x3FF+52 )
       return af;
    if ( s )
-      y = ::f64_add( ::f64_sub( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} );
+      y = ::f64_add( ::f64_sub( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} );
    else
-      y = ::f64_sub( ::f64_add( a, float64_t{inv_double_eps} ), float64_t{inv_double_eps} );
-   if ( ::f64_eq( y, float64_t{0} ) )
+      y = ::f64_sub( ::f64_add( a, softfloat64_t{inv_double_eps} ), softfloat64_t{inv_double_eps} );
+   if ( ::f64_eq( y, softfloat64_t{0} ) )
       return s ? -0.0 : 0.0;
    return from_softfloat64(y);
 }
@@ -347,8 +347,8 @@ inline bool _sysio_f64_ne( double a, double b ) { return !::f64_eq( to_softfloat
 inline bool _sysio_f64_lt( double a, double b ) { return ::f64_lt( to_softfloat64(a), to_softfloat64(b) ); }
 inline bool _sysio_f64_le( double a, double b ) { return ::f64_le( to_softfloat64(a), to_softfloat64(b) ); }
 inline bool _sysio_f64_gt( double af, double bf ) {
-   float64_t a = to_softfloat64(af);
-   float64_t b = to_softfloat64(bf);
+   softfloat64_t a = to_softfloat64(af);
+   softfloat64_t b = to_softfloat64(bf);
    if (is_nan(a))
       return false;
    if (is_nan(b))
@@ -357,8 +357,8 @@ inline bool _sysio_f64_gt( double af, double bf ) {
 }
 
 inline bool _sysio_f64_ge( double af, double bf ) {
-   float64_t a = to_softfloat64(af);
-   float64_t b = to_softfloat64(bf);
+   softfloat64_t a = to_softfloat64(af);
+   softfloat64_t b = to_softfloat64(bf);
    if (is_nan(a))
       return false;
    if (is_nan(b))
@@ -375,7 +375,7 @@ inline float _sysio_f64_demote( double a ) {
 }
 
 inline int32_t _sysio_f32_trunc_i32s( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    SYS_VM_ASSERT(!(_sysio_f32_ge(af, 2147483648.0f) || _sysio_f32_lt(af, -2147483648.0f)), wasm_interpreter_exception, "Error, f32.convert_s/i32 overflow" );
 
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f32.convert_s/i32 unrepresentable");
@@ -383,35 +383,35 @@ inline int32_t _sysio_f32_trunc_i32s( float af ) {
 }
 
 inline int32_t _sysio_f64_trunc_i32s( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    SYS_VM_ASSERT(!(_sysio_f64_ge(af, 2147483648.0) || _sysio_f64_lt(af, -2147483648.0)), wasm_interpreter_exception, "Error, f64.convert_s/i32 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f64.convert_s/i32 unrepresentable");
    return f64_to_i32( to_softfloat64(_sysio_f64_trunc( af )), 0, false );
 }
 
 inline uint32_t _sysio_f32_trunc_i32u( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    SYS_VM_ASSERT(!(_sysio_f32_ge(af, 4294967296.0f) || _sysio_f32_le(af, -1.0f)),wasm_interpreter_exception, "Error, f32.convert_u/i32 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f32.convert_u/i32 unrepresentable");
    return f32_to_ui32( to_softfloat32(_sysio_f32_trunc( af )), 0, false );
 }
 
 inline uint32_t _sysio_f64_trunc_i32u( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    SYS_VM_ASSERT(!(_sysio_f64_ge(af, 4294967296.0) || _sysio_f64_le(af, -1.0)), wasm_interpreter_exception, "Error, f64.convert_u/i32 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f64.convert_u/i32 unrepresentable");
    return f64_to_ui32( to_softfloat64(_sysio_f64_trunc( af )), 0, false );
 }
 
 inline int64_t _sysio_f32_trunc_i64s( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
       SYS_VM_ASSERT(!(_sysio_f32_ge(af, 9223372036854775808.0f) || _sysio_f32_lt(af, -9223372036854775808.0f)), wasm_interpreter_exception, "Error, f32.convert_s/i64 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f32.convert_s/i64 unrepresentable");
    return f32_to_i64( to_softfloat32(_sysio_f32_trunc( af )), 0, false );
 }
 
 inline int64_t _sysio_f64_trunc_i64s( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    SYS_VM_ASSERT(!(_sysio_f64_ge(af, 9223372036854775808.0) || _sysio_f64_lt(af, -9223372036854775808.0)), wasm_interpreter_exception, "Error, f64.convert_s/i64 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f64.convert_s/i64 unrepresentable");
 
@@ -419,14 +419,14 @@ inline int64_t _sysio_f64_trunc_i64s( double af ) {
 }
 
 inline uint64_t _sysio_f32_trunc_i64u( float af ) {
-   float32_t a = to_softfloat32(af);
+   softfloat32_t a = to_softfloat32(af);
    SYS_VM_ASSERT(!(_sysio_f32_ge(af, 18446744073709551616.0f) || _sysio_f32_le(af, -1.0f)), wasm_interpreter_exception, "Error, f32.convert_u/i64 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f32.convert_u/i64 unrepresentable");
    return f32_to_ui64( to_softfloat32(_sysio_f32_trunc( af )), 0, false );
 }
 
 inline uint64_t _sysio_f64_trunc_i64u( double af ) {
-   float64_t a = to_softfloat64(af);
+   softfloat64_t a = to_softfloat64(af);
    SYS_VM_ASSERT(!(_sysio_f64_ge(af, 18446744073709551616.0) || _sysio_f64_le(af, -1.0)), wasm_interpreter_exception, "Error, f64.convert_u/i64 overflow");
    SYS_VM_ASSERT(!is_nan(a), wasm_interpreter_exception, "Error, f64.convert_u/i64 unrepresentable");
    return f64_to_ui64( to_softfloat64(_sysio_f64_trunc( af )), 0, false );

--- a/include/sysio/vm/x86_64.hpp
+++ b/include/sysio/vm/x86_64.hpp
@@ -877,47 +877,47 @@ namespace sysio { namespace vm {
       static uint64_t adapt_result(bool val) {
          return val?1:0;
       }
-      static uint64_t adapt_result(float32_t val) {
+      static uint64_t adapt_result(softfloat32_t val) {
          uint64_t result = 0;
-         std::memcpy(&result, &val, sizeof(float32_t));
+         std::memcpy(&result, &val, sizeof(softfloat32_t));
          return result;
       }
-      static float64_t adapt_result(float64_t val) {
+      static softfloat64_t adapt_result(softfloat64_t val) {
          return val;
       }
 
       template<auto F>
-      static auto adapt_f32_unop(float32_t arg) {
+      static auto adapt_f32_unop(softfloat32_t arg) {
         return ::to_softfloat32(static_cast<decltype(F)>(F)(::from_softfloat32(arg)));
       }
       template<auto F>
-      static auto adapt_f32_binop(float32_t lhs, float32_t rhs) {
+      static auto adapt_f32_binop(softfloat32_t lhs, softfloat32_t rhs) {
          return ::to_softfloat32(static_cast<decltype(F)>(F)(::from_softfloat32(lhs), ::from_softfloat32(rhs)));
       }
       template<auto F>
-      static auto adapt_f32_cmp(float32_t lhs, float32_t rhs) {
+      static auto adapt_f32_cmp(softfloat32_t lhs, softfloat32_t rhs) {
          return adapt_result(static_cast<decltype(F)>(F)(::from_softfloat32(lhs), ::from_softfloat32(rhs)));
       }
 
       template<auto F>
-      static auto adapt_f64_unop(float64_t arg) {
+      static auto adapt_f64_unop(softfloat64_t arg) {
          return ::to_softfloat64(static_cast<decltype(F)>(F)(::from_softfloat64(arg)));
       }
       template<auto F>
-      static auto adapt_f64_binop(float64_t lhs, float64_t rhs) {
+      static auto adapt_f64_binop(softfloat64_t lhs, softfloat64_t rhs) {
          return ::to_softfloat64(static_cast<decltype(F)>(F)(::from_softfloat64(lhs), ::from_softfloat64(rhs)));
       }
       template<auto F>
-      static auto adapt_f64_cmp(float64_t lhs, float64_t rhs) {
+      static auto adapt_f64_cmp(softfloat64_t lhs, softfloat64_t rhs) {
          return adapt_result(static_cast<decltype(F)>(F)(::from_softfloat64(lhs), ::from_softfloat64(rhs)));
       }
 
-      static float32_t to_softfloat(float arg) { return ::to_softfloat32(arg); }
-      static float64_t to_softfloat(double arg) { return ::to_softfloat64(arg); }
+      static softfloat32_t to_softfloat(float arg) { return ::to_softfloat32(arg); }
+      static softfloat64_t to_softfloat(double arg) { return ::to_softfloat64(arg); }
       template<typename T>
       static T to_softfloat(T arg) { return arg; }
-      static float from_softfloat(float32_t arg) { return ::from_softfloat32(arg); }
-      static double from_softfloat(float64_t arg) { return ::from_softfloat64(arg); }
+      static float from_softfloat(softfloat32_t arg) { return ::from_softfloat32(arg); }
+      static double from_softfloat(softfloat64_t arg) { return ::from_softfloat64(arg); }
       template<typename T>
       static T from_softfloat(T arg) { return arg; }
 
@@ -992,8 +992,8 @@ namespace sysio { namespace vm {
 
    #define CHOOSE_FN(name) choose_fn<&name>()
 #else
-      using float32_t = float;
-      using float64_t = double;
+      using softfloat32_t = float;
+      using softfloat64_t = double;
    #define CHOOSE_FN(name) nullptr
 #endif
 
@@ -2333,7 +2333,7 @@ namespace sysio { namespace vm {
          }
       }
 
-      void emit_f32_binop_softfloat(float32_t (*softfloatfun)(float32_t, float32_t)) {
+      void emit_f32_binop_softfloat(softfloat32_t (*softfloatfun)(softfloat32_t, softfloat32_t)) {
          auto extra = emit_setup_backtrace();
          // pushq %rdi
          emit_bytes(0x57);
@@ -2361,7 +2361,7 @@ namespace sysio { namespace vm {
          emit_bytes(0x89, 0x04, 0x24);
       }
 
-      void emit_f64_binop_softfloat(float64_t (*softfloatfun)(float64_t, float64_t)) {
+      void emit_f64_binop_softfloat(softfloat64_t (*softfloatfun)(softfloat64_t, softfloat64_t)) {
          auto extra = emit_setup_backtrace();
          // pushq %rdi
          emit_bytes(0x57);
@@ -2389,7 +2389,7 @@ namespace sysio { namespace vm {
          emit_bytes(0x48, 0x89, 0x04, 0x24);
       }
 
-      void emit_f32_relop(uint8_t opcode, uint64_t (*softfloatfun)(float32_t, float32_t), bool switch_params, bool flip_result) {
+      void emit_f32_relop(uint8_t opcode, uint64_t (*softfloatfun)(softfloat32_t, softfloat32_t), bool switch_params, bool flip_result) {
          if constexpr (use_softfloat) {
             auto extra = emit_setup_backtrace();
             // pushq %rdi
@@ -2456,7 +2456,7 @@ namespace sysio { namespace vm {
          }
       }
 
-      void emit_f64_relop(uint8_t opcode, uint64_t (*softfloatfun)(float64_t, float64_t), bool switch_params, bool flip_result) {
+      void emit_f64_relop(uint8_t opcode, uint64_t (*softfloatfun)(softfloat64_t, softfloat64_t), bool switch_params, bool flip_result) {
          if constexpr (use_softfloat) {
             auto extra = emit_setup_backtrace();
             // pushq %rdi
@@ -2545,7 +2545,7 @@ namespace sysio { namespace vm {
          emit_bytes(static_cast<uint8_t>(op)...);
       }
 
-      void emit_f32_binop(uint8_t op, float32_t (*softfloatfun)(float32_t, float32_t)) {
+      void emit_f32_binop(uint8_t op, softfloat32_t (*softfloatfun)(softfloat32_t, softfloat32_t)) {
          if constexpr (use_softfloat) {
             return emit_f32_binop_softfloat(softfloatfun);
          }
@@ -2559,7 +2559,7 @@ namespace sysio { namespace vm {
          emit_bytes(0xf3, 0x0f, 0x11, 0x04, 0x24);
       }
 
-      void emit_f64_binop(uint8_t op, float64_t (*softfloatfun)(float64_t, float64_t)) {
+      void emit_f64_binop(uint8_t op, softfloat64_t (*softfloatfun)(softfloat64_t, softfloat64_t)) {
          if constexpr (use_softfloat) {
             return emit_f64_binop_softfloat(softfloatfun);
          }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -9,7 +9,8 @@
     {
       "kind": "git",
       "repository": "https://github.com/wire-network/wire-vcpkg-registry",
-      "baseline": "add9228a61ce5eb1dc41f89d07254b7531b2bdfc",
+      "baseline": "270e23ca7cbbf0dc7f2576126d33485163a5e364",
+      "reference": "270e23ca7cbbf0dc7f2576126d33485163a5e364",
       "packages": [
         "softfloat"
       ]


### PR DESCRIPTION
## Summary
- Update sys-vm's SoftFloat integration to use the canonical `softfloat32_t` and `softfloat64_t` type names.
- Point the local Wire vcpkg registry config at the registry commit that contains `softfloat@3.0.0#1`.
- Bump the CMake package version to `1.1.1` to match the registry port version consuming this change.

## What changed
- Renamed legacy SoftFloat carrier types in `include/sysio/vm/softfloat.hpp` and the x86_64 softfloat glue.
- Kept the non-SoftFloat x86_64 fallback aliases, but renamed them to the new canonical names so templated call sites stay uniform.
- Added the registry `reference` pin alongside the baseline so standalone eos-vm builds resolve the fixed SoftFloat port.

## Why
`softfloat@3.0.0#1` exports `SOFTFLOAT_DISABLE_LEGACY_TYPE_ALIASES`, so consumers can no longer rely on `float32_t` and `float64_t`. This lets sys-vm build against the fixed SoftFloat package used by the macOS arm64 Wire Sysio dependency update.

## Testing
- `cmake -B build/softfloat-rename -S . -G Ninja -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTS=OFF -DENABLE_SOFTFLOAT_INSTALL=OFF -DCMAKE_INSTALL_PREFIX=/tmp/eos-vm-softfloat-rename-install -DCMAKE_TOOLCHAIN_FILE=$PWD/../wire-sysio/vcpkg/scripts/buildsystems/vcpkg.cmake`
- `cmake --build build/softfloat-rename --target install -- -j6`

