### PR TITLE
Fix Clang unroll warning in LEB128 helpers

### DIFF
--- a/include/sysio/vm/leb128.hpp
+++ b/include/sysio/vm/leb128.hpp
@@ -37,7 +37,9 @@ namespace sysio { namespace vm {
          inline constexpr void from(uint32_t v) {
              bytes_used = 0;
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#pragma clang loop unroll_count(5)
+#elif defined(__GNUC__)
 #pragma GCC unroll 5
 #endif
             for (; bytes_used < bytes_needed<N>(); bytes_used++) {
@@ -81,7 +83,9 @@ namespace sysio { namespace vm {
          inline constexpr uint32_t to() {
             uint32_t ret = 0;
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#pragma clang loop unroll_count(5)
+#elif defined(__GNUC__)
 #pragma GCC unroll 5
 #endif
             for (int i=bytes_used-1; i >= 0; i--) {
@@ -176,7 +180,9 @@ namespace sysio { namespace vm {
          inline constexpr void _from(T v) {
             bytes_used = 0;
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#pragma clang loop unroll_count(5)
+#elif defined(__GNUC__)
 #pragma GCC unroll 5
 #endif
             for (; bytes_used < bytes_needed<N>(); bytes_used++) {
@@ -193,7 +199,9 @@ namespace sysio { namespace vm {
          inline constexpr T _to() {
             typename std::make_unsigned<T>::type ret = 0;
 
-#if defined(__GNUC__) && !defined(__clang__)
+#if defined(__clang__)
+#pragma clang loop unroll_count(5)
+#elif defined(__GNUC__)
 #pragma GCC unroll 5
 #endif
             for (int i=bytes_used-1; i >= 0; i--) {

--- a/include/sysio/vm/leb128.hpp
+++ b/include/sysio/vm/leb128.hpp
@@ -37,7 +37,7 @@ namespace sysio { namespace vm {
          inline constexpr void from(uint32_t v) {
              bytes_used = 0;
 
-#if defined(__clang__)
+#ifdef __clang__
 #pragma clang loop unroll_count(5)
 #elif defined(__GNUC__)
 #pragma GCC unroll 5
@@ -83,7 +83,7 @@ namespace sysio { namespace vm {
          inline constexpr uint32_t to() {
             uint32_t ret = 0;
 
-#if defined(__clang__)
+#ifdef __clang__
 #pragma clang loop unroll_count(5)
 #elif defined(__GNUC__)
 #pragma GCC unroll 5
@@ -180,7 +180,7 @@ namespace sysio { namespace vm {
          inline constexpr void _from(T v) {
             bytes_used = 0;
 
-#if defined(__clang__)
+#ifdef __clang__
 #pragma clang loop unroll_count(5)
 #elif defined(__GNUC__)
 #pragma GCC unroll 5
@@ -199,7 +199,7 @@ namespace sysio { namespace vm {
          inline constexpr T _to() {
             typename std::make_unsigned<T>::type ret = 0;
 
-#if defined(__clang__)
+#ifdef __clang__
 #pragma clang loop unroll_count(5)
 #elif defined(__GNUC__)
 #pragma GCC unroll 5

--- a/include/sysio/vm/leb128.hpp
+++ b/include/sysio/vm/leb128.hpp
@@ -37,9 +37,7 @@ namespace sysio { namespace vm {
          inline constexpr void from(uint32_t v) {
              bytes_used = 0;
 
-#ifdef __clang__
-#pragma unroll
-#elif defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC unroll 5
 #endif
             for (; bytes_used < bytes_needed<N>(); bytes_used++) {
@@ -83,9 +81,7 @@ namespace sysio { namespace vm {
          inline constexpr uint32_t to() {
             uint32_t ret = 0;
 
-#ifdef __clang__
-#pragma unroll
-#elif defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC unroll 5
 #endif
             for (int i=bytes_used-1; i >= 0; i--) {
@@ -180,9 +176,7 @@ namespace sysio { namespace vm {
          inline constexpr void _from(T v) {
             bytes_used = 0;
 
-#ifdef __clang__
-#pragma unroll
-#elif defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC unroll 5
 #endif
             for (; bytes_used < bytes_needed<N>(); bytes_used++) {
@@ -199,9 +193,7 @@ namespace sysio { namespace vm {
          inline constexpr T _to() {
             typename std::make_unsigned<T>::type ret = 0;
 
-#ifdef __clang__
-#pragma unroll
-#elif defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__clang__)
 #pragma GCC unroll 5
 #endif
             for (int i=bytes_used-1; i >= 0; i--) {


### PR DESCRIPTION
## Change Description

Replace Clang's forced `#pragma unroll` (full unroll) hint on the LEB128 helper loops with `#pragma clang loop unroll_count(5)`. These loops can terminate early based on encoded byte contents, so a *forced full* unroll request has no fallback and Clang emits `-Wpass-failed=transform-warning` when it can't comply (seen in downstream Release builds, reproduced locally with Homebrew llvm@18 at `-O2`/`-O3 -Wall`).

`unroll_count(5)` requests a partial unroll by a fixed factor instead. Unlike a forced full unroll, it has a runtime-remainder-loop fallback, so it succeeds without warning — while still giving Clang an unroll hint (previously these loops would have had no hint at all under one earlier version of this fix). This also makes the Clang hint symmetric with GCC's existing `#pragma GCC unroll 5`, which was already count-based rather than forcing a full unroll.

`#ifdef __clang__` / `#elif defined(__GNUC__)` guard style kept consistent with the rest of the file.

## API Changes
- [ ] API Changes

No API changes.

## Documentation Additions
- [ ] Documentation Additions

No documentation additions required.

## Testing

- `cmake -S . -B build/release -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_TOOLCHAIN_FILE=./vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_OVERLAY_TRIPLETS=build/vcpkg-triplets -DVCPKG_TARGET_TRIPLET=arm64-osx-release -DENABLE_TESTS=ON -DENABLE_SPEC_TESTS=ON -DENABLE_CCACHE=ON`
- `cmake --build build/release -j` — clean build, no `leb128.hpp` warnings
- `ctest -j --output-on-failure` — 5151/5151 tests passed
- Verified directly with Homebrew `llvm@18` (`clang++ -std=c++17 -O2/-O3 -Wall`) on the real header: `-Wpass-failed=transform-warning` reproduced with bare `#pragma unroll`, gone with `#pragma clang loop unroll_count(5)`
